### PR TITLE
Fix use of datetime in webhook auth

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -1,5 +1,5 @@
 name: Unit Tests
-on: push
+on: pull_request
 jobs:
   phpunit:
     name: PHPUnit (PHP ${{ matrix.php-versions }})

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -1,0 +1,31 @@
+name: Unit Tests
+on: push
+jobs:
+  phpunit:
+    name: PHPUnit (PHP ${{ matrix.php-versions }})
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php-versions: ['7.3', '7.4']
+      fail-fast: false
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup PHP, with composer and extensions
+        uses: shivammathur/setup-php@v2 #https://github.com/shivammathur/setup-php
+        with:
+          php-version: ${{ matrix.php-versions }}
+          tools: composer:v1
+      - name: Get composer cache directory
+        id: composer-cache
+        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+      - name: Cache composer dependencies
+        uses: actions/cache@v1
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
+          restore-keys: ${{ runner.os }}-composer-
+      - name: Install Composer dependencies
+        run: composer install --no-progress --no-suggest --prefer-dist --optimize-autoloader
+      - name: Test with phpunit
+        run: vendor/bin/phpunit

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@
 .idea/misc.xml
 /vendor
 composer.lock
+
+# PHPUnit
+/.phpunit.cache
+.phpunit.result.cache

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .idea/modulr-hmac-php-client.iml
 .idea/modules.xml
 .idea/misc.xml
+/vendor

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 .idea/modules.xml
 .idea/misc.xml
 /vendor
+composer.lock

--- a/composer.json
+++ b/composer.json
@@ -7,9 +7,18 @@
     "nesbot/carbon": "^1.26.3 || ^2.0",
     "monolog/monolog": "1.*"
   },
+  "require-dev": {
+    "phpunit/phpunit": "^8.3",
+    "orchestra/testbench": "^v4.0"
+  },
   "autoload": {
     "psr-4" : {
       "CrowdProperty\\ModulrHmacPhpClient\\" : "src"
+    }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "Tests\\": "tests/"
     }
   }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" backupStaticAttributes="false" bootstrap="vendor/autoload.php" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <testsuites>
+    <testsuite name="Feature">
+      <directory suffix="Test.php">./tests/Feature</directory>
+    </testsuite>
+    <testsuite name="Unit">
+      <directory suffix="Test.php">./tests/Unit</directory>
+    </testsuite>
+  </testsuites>
+  <php>
+    <env name="APP_ENV" value="testing"/>
+    <env name="MODULR_LOG_HEADERS" value="false"/>
+    <env name="MODULR_HOOK_SECRET" value="abcd1234-test-secret"/>
+  </php>
+</phpunit>

--- a/src/Http/Middleware/VerifyModulrHmac.php
+++ b/src/Http/Middleware/VerifyModulrHmac.php
@@ -12,7 +12,12 @@ use Monolog\Handler\StreamHandler;
 
 class VerifyModulrHmac
 {
-
+    /**
+     * Time in seconds we should allow timestamp of incoming requests to differ from server time.
+     *
+     * Requests outside this limit will be rejected. This prevents replay attacks.
+     */
+    protected const DATE_TIME_TOLERANCE = 10;
 
     protected function parseSignature($signature)
     {
@@ -46,6 +51,11 @@ class VerifyModulrHmac
             $log->pushHandler(new StreamHandler(storage_path('logs/modulr/headers.log'), Logger::INFO));
             $log->info("HEADERS: " . print_r($request->headers->all(), true));
         }
+
+        if (Carbon::parse($request->header('Date'))->diffInSeconds() > self::DATE_TIME_TOLERANCE) {
+            \App::abort(401, 'Date value outside expected tolerance');
+        }
+
         $signatureArray = $this->parseSignature($request->header('Authorization'));
         $client->setApiKey($signatureArray['Signature keyId']);
         $client->setHmacSecret(md5(env('MODULR_HOOK_SECRET')));

--- a/src/Http/Middleware/VerifyModulrHmac.php
+++ b/src/Http/Middleware/VerifyModulrHmac.php
@@ -51,6 +51,7 @@ class VerifyModulrHmac
         $client->setHmacSecret(md5(env('MODULR_HOOK_SECRET')));
         $client->setNonce($request->header('X-Mod-Nonce'));
         $client->setTimezone('GMT');
+        $client->setDate(Carbon::parse($request->header('Date')));
 
         if(env('MODULR_LOG_HEADERS')) {
             $log->info('GENERATED AUTH STRING: ' . $client->authorisationString());

--- a/src/ModulrApi.php
+++ b/src/ModulrApi.php
@@ -98,7 +98,10 @@ class ModulrApi
      */
     public function getDate()
     {
-        $this->setDate(Carbon::now($this->timezone));
+        if (is_null($this->date)) {
+            $this->setDate(Carbon::now($this->timezone));
+        }
+
         return $this->date->format('D, d M Y H:i:s e');
     }
 

--- a/src/ModulrApi.php
+++ b/src/ModulrApi.php
@@ -266,6 +266,9 @@ class ModulrApi
             $config->addDefaultHeader('x-mod-retry', true);
         }
 
+        // Refresh date when creating new clients
+        $this->setDate(Carbon::now());
+
         $config->setApiKey('Authorization', $this->authorisationString());
 
         $config->setHost($this->apiPath);

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Tests;
+
+class TestCase extends \Orchestra\Testbench\TestCase
+{
+    //
+}

--- a/tests/Unit/Http/Middleware/VerifyModulrHmacTest.php
+++ b/tests/Unit/Http/Middleware/VerifyModulrHmacTest.php
@@ -1,0 +1,141 @@
+<?php
+
+namespace Tests\Unit\Http\Middleware;
+
+use Carbon\Carbon;
+use Tests\TestCase;
+use Illuminate\Http\Request;
+use CrowdProperty\ModulrHmacPhpClient\Http\Middleware\VerifyModulrHmac;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+class VerifyModulrHmacTest extends TestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        // set Carbon to use fixed datetime as "now" during these tests
+        $knownDate = Carbon::parse('2020-11-01 12:12:23 GMT');
+        Carbon::setTestNow($knownDate);
+    }
+
+    /**
+     * A valid request, arriving at exact time as specified in Date header.
+     *
+     * @return void
+     */
+    public function testPassingRequest ()
+    {
+        $request = new Request;
+        $request->headers->add([
+            'Authorization' => 'Signature keyId="57502612d1bb2c0001000025fd53850cd9a94861507a5f7cca236882",algorithm="hmac-sha1",headers="date x-mod-nonce",signature="BPZ%2FIsFA0SQPLesj%2FPrHssUxl24%3D"',
+            'Date' => '2020-11-01 12:12:23 GMT',
+            'X-Mod-Nonce' => 'ABCD12345'
+            ]);
+
+        $middleware = new VerifyModulrHmac;
+
+        $middleware->handle($request, function ($req) {
+            $this->assertTrue(true);
+        });
+    }
+
+    /**
+     * A valid request, arriving a few seconds after date in Date header - but within allowed tolerance.
+     *
+     * @return void
+     */
+    public function testSlightlyOffTimeRequest ()
+    {
+        $request = new Request;
+        $request->headers->add([
+            'Authorization' => 'Signature keyId="57502612d1bb2c0001000025fd53850cd9a94861507a5f7cca236882",algorithm="hmac-sha1",headers="date x-mod-nonce",signature="BPZ%2FIsFA0SQPLesj%2FPrHssUxl24%3D"',
+            'Date' => '2020-11-01 12:12:23 GMT',
+            'X-Mod-Nonce' => 'ABCD12345'
+            ]);
+
+        // Set time that Carbon considers as present to 8 seconds after date in Date header
+        Carbon::setTestNow(Carbon::parse('2020-11-01 12:12:31 GMT'));
+
+        $middleware = new VerifyModulrHmac;
+
+        $middleware->handle($request, function ($req) {
+            $this->assertTrue(true);
+        });
+    }
+
+    /**
+     * An invalid request, arriving too many seconds after date in Date header - ie outside allowed tolerance.
+     *
+     * @return void
+     */
+    public function testTooFarOffTimeRequest ()
+    {
+        $request = new Request;
+        $request->headers->add([
+            'Authorization' => 'Signature keyId="57502612d1bb2c0001000025fd53850cd9a94861507a5f7cca236882",algorithm="hmac-sha1",headers="date x-mod-nonce",signature="BPZ%2FIsFA0SQPLesj%2FPrHssUxl24%3D"',
+            'Date' => '2020-11-01 12:12:23 GMT',
+            'X-Mod-Nonce' => 'ABCD12345'
+            ]);
+
+        // Set time that Carbon considers as present to 12 seconds after date in Date header
+        Carbon::setTestNow(Carbon::parse('2020-11-01 12:12:35 GMT'));
+
+        $middleware = new VerifyModulrHmac;
+
+        $this->expectException(HttpException::class);
+
+        $middleware->handle($request, function ($req) {
+            // we shouldn't get here, so trigger failure if we do
+            $this->assertTrue(false, "Fail: the request was allowed to continue");
+        });
+    }
+
+    /**
+     * Check incorrect nonce triggers exception
+     *
+     * @return void
+     */
+    public function testIncorrectNonce ()
+    {
+        $request = new Request;
+        $request->headers->add([
+            'Authorization' => 'Signature keyId="57502612d1bb2c0001000025fd53850cd9a94861507a5f7cca236882",algorithm="hmac-sha1",headers="date x-mod-nonce",signature="BPZ%2FIsFA0SQPLesj%2FPrHssUxl24%3D"',
+            'Date' => '2020-11-01 12:12:23 GMT',
+            'X-Mod-Nonce' => 'Wrong nonce'
+            ]);
+
+        $middleware = new VerifyModulrHmac;
+
+        $this->expectException(HttpException::class);
+
+        $middleware->handle($request, function ($req) {
+            // we shouldn't get here, so trigger failure if we do
+            $this->assertTrue(false, "Fail: the request was allowed to continue");
+        });
+    }
+
+    /**
+     * Check incorrect signature triggers failure.
+     *
+     * @return void
+     */
+    public function testIncorrectSignature ()
+    {
+        $request = new Request;
+        $request->headers->add([
+            'Authorization' => 'Signature keyId="57502612d1bb2c0001000025fd53850cd9a94861507a5f7cca236882",algorithm="hmac-sha1",headers="date x-mod-nonce",signature="wrong sig !"',
+            'Date' => '2020-11-01 12:12:23 GMT',
+            'X-Mod-Nonce' => 'ABCD12345'
+            ]);
+
+        $middleware = new VerifyModulrHmac;
+
+        $this->expectException(HttpException::class);
+
+        $middleware->handle($request, function ($req) {
+            // we shouldn't get here, so trigger failure if we do
+            $this->assertTrue(false, "Fail: the request was allowed to continue");
+        });
+    }
+}

--- a/tests/Unit/ModulrApiTest.php
+++ b/tests/Unit/ModulrApiTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Tests\Unit;
+
+use Carbon\Carbon;
+use CrowdProperty\ModulrHmacPhpClient\ModulrApi;
+use Tests\TestCase;
+
+class ModulrApiTest extends TestCase
+{
+    /**
+     * Check new clients created get the current time set.
+     *
+     * So that request signatures are valid, rather than out of date if clients creating during long-running process
+     * such as job handler.
+     *
+     * @return void
+     */
+    public function testClientsGetCurrentDateSet()
+    {
+        $client = new ModulrApi();
+
+        $initialTime = Carbon::parse('2020-11-01 02:00:00 GMT');
+        $laterTime   = Carbon::parse('2020-11-01 15:00:00 GMT');
+
+        $client->setApiKey('abcde');
+        $client->setHmacSecret('abcde');
+        $client->setNonce('1234');
+        $client->setTimezone('GMT');
+        $client->setDate($initialTime);
+
+        // Set "current" time (i.e. in test env), to the later time
+        Carbon::setTestNow($initialTime);
+
+        // Just for completeness, check the time returned initially, is exactly the time we set
+        $initialPaymentsClient = $client->payments();
+        $date = Carbon::parse($initialPaymentsClient->getApiClient()->getConfig()->getDefaultHeaders()["Date"]);
+        $this->assertEquals(0, $date->diffInSeconds($initialTime));
+
+        // Set "current" time (i.e. in test env), to the later time
+        Carbon::setTestNow($laterTime);
+
+        // get a new payments client
+        $laterPaymentsClient = $client->payments();
+
+        // Check that the later client has had the date refreshed as the later time
+        $date = Carbon::parse($laterPaymentsClient->getApiClient()->getConfig()->getDefaultHeaders()["Date"]);
+        $this->assertEquals(0, $date->diffInSeconds($laterTime));
+    }
+}


### PR DESCRIPTION
The current datetime was being used when checking webhook auth string, but this suffered from the fact that sometimes 1 second would have ticked by between the request being generated, and handled on the receive side. The request would then be rejected.

The one benefit of this method was that older requests (eg replay attack) would automatically be rejected.

The update in this PR sets the auth to use the supplied datetime, and hence also needs to check the datetime isn't too far off the current time (to protect against replay attacks).

Unit tests have been added to cover each situation re timing, and also other auth aspects (nonce, signature). Also added github action to run unit tests as part of PRs.